### PR TITLE
feat: add sandbox integration test infrastructure

### DIFF
--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -1,0 +1,41 @@
+name: Sandbox Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run daily at 08:00 UTC to catch sandbox API changes early.
+    - cron: '0 8 * * *'
+
+jobs:
+  sandbox:
+    name: Sandbox Integration Tests
+    if: github.repository_owner == 'MonumentalSystems'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Run sandbox tests
+        env:
+          MERCURY_SANDBOX_TOKEN: ${{ secrets.MERCURY_SANDBOX_TOKEN }}
+        run: dotnet test tests/MercuryBankApi.Sandbox.Tests --no-build --logger "console;verbosity=detailed"

--- a/MercuryBankApi.slnx
+++ b/MercuryBankApi.slnx
@@ -4,5 +4,6 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/MercuryBankApi.Tests/MercuryBankApi.Tests.csproj" />
+    <Project Path="tests/MercuryBankApi.Sandbox.Tests/MercuryBankApi.Sandbox.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/MercuryBankApi/MercuryBankOptions.cs
+++ b/src/MercuryBankApi/MercuryBankOptions.cs
@@ -8,8 +8,14 @@ public sealed class MercuryBankOptions
     /// <summary>Configuration section name for binding.</summary>
     public const string SectionName = "Mercury";
 
+    /// <summary>Production API base URL.</summary>
+    public const string ProductionBaseUrl = "https://api.mercury.com/api/v1";
+
+    /// <summary>Sandbox API base URL for testing.</summary>
+    public const string SandboxBaseUrl = "https://api-sandbox.mercury.com/api/v1";
+
     /// <summary>Mercury API base URL. Defaults to production.</summary>
-    public string BaseUrl { get; set; } = "https://api.mercury.com/api/v1";
+    public string BaseUrl { get; set; } = ProductionBaseUrl;
 
     /// <summary>Mercury API bearer token.</summary>
     public string ApiToken { get; set; } = string.Empty;

--- a/tests/MercuryBankApi.Sandbox.Tests/AccountTests.cs
+++ b/tests/MercuryBankApi.Sandbox.Tests/AccountTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+
+namespace MercuryBankApi.Sandbox.Tests;
+
+/// <summary>
+/// Integration tests for account-related operations against the Mercury sandbox.
+/// </summary>
+public class AccountTests : IClassFixture<SandboxFixture>
+{
+    private readonly SandboxFixture _sandbox;
+
+    public AccountTests(SandboxFixture sandbox)
+    {
+        _sandbox = sandbox;
+    }
+
+    [SandboxFact]
+    public async Task GetAccountsAsync_ReturnsSandboxAccounts()
+    {
+        var accounts = await _sandbox.Client.GetAccountsAsync();
+
+        accounts.Should().NotBeEmpty("sandbox should have pre-loaded accounts");
+    }
+
+    [SandboxFact]
+    public async Task GetAccountAsync_ReturnsSingleAccount()
+    {
+        var accounts = await _sandbox.Client.GetAccountsAsync();
+        accounts.Should().NotBeEmpty();
+
+        var account = await _sandbox.Client.GetAccountAsync(accounts[0].Id);
+
+        account.Should().NotBeNull();
+        account.Id.Should().Be(accounts[0].Id);
+        account.Name.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/MercuryBankApi.Sandbox.Tests/GlobalUsings.cs
+++ b/tests/MercuryBankApi.Sandbox.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/MercuryBankApi.Sandbox.Tests/MercuryBankApi.Sandbox.Tests.csproj
+++ b/tests/MercuryBankApi.Sandbox.Tests/MercuryBankApi.Sandbox.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/MercuryBankApi/MercuryBankApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/MercuryBankApi.Sandbox.Tests/SandboxFactAttribute.cs
+++ b/tests/MercuryBankApi.Sandbox.Tests/SandboxFactAttribute.cs
@@ -1,0 +1,17 @@
+namespace MercuryBankApi.Sandbox.Tests;
+
+/// <summary>
+/// A <see cref="FactAttribute"/> that skips the test when the
+/// <c>MERCURY_SANDBOX_TOKEN</c> environment variable is not set.
+/// </summary>
+public sealed class SandboxFactAttribute : FactAttribute
+{
+    public SandboxFactAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("MERCURY_SANDBOX_TOKEN")))
+        {
+            Skip = "MERCURY_SANDBOX_TOKEN environment variable is not set. " +
+                   "Provide a sandbox API token to run integration tests.";
+        }
+    }
+}

--- a/tests/MercuryBankApi.Sandbox.Tests/SandboxFixture.cs
+++ b/tests/MercuryBankApi.Sandbox.Tests/SandboxFixture.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MercuryBankApi.Sandbox.Tests;
+
+/// <summary>
+/// Shared fixture that creates a configured <see cref="IMercuryBankClient"/>
+/// pointing at the Mercury sandbox environment.
+/// <para>
+/// Required environment variable: <c>MERCURY_SANDBOX_TOKEN</c>.
+/// Tests that depend on this fixture are automatically skipped when the
+/// token is not set.
+/// </para>
+/// </summary>
+public sealed class SandboxFixture : IDisposable
+{
+    private readonly ServiceProvider _provider;
+
+    public SandboxFixture()
+    {
+        var token = Environment.GetEnvironmentVariable("MERCURY_SANDBOX_TOKEN");
+
+        IsConfigured = !string.IsNullOrWhiteSpace(token);
+
+        var services = new ServiceCollection();
+
+        services.AddMercuryBankApi(opts =>
+        {
+            opts.BaseUrl = MercuryBankOptions.SandboxBaseUrl;
+            opts.ApiToken = token ?? string.Empty;
+        });
+
+        _provider = services.BuildServiceProvider();
+    }
+
+    /// <summary>Whether sandbox credentials are available.</summary>
+    public bool IsConfigured { get; }
+
+    /// <summary>Gets the configured sandbox client.</summary>
+    public IMercuryBankClient Client =>
+        _provider.GetRequiredService<IMercuryBankClient>();
+
+    public void Dispose() => _provider.Dispose();
+}

--- a/tests/MercuryBankApi.Sandbox.Tests/TransactionTests.cs
+++ b/tests/MercuryBankApi.Sandbox.Tests/TransactionTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+
+namespace MercuryBankApi.Sandbox.Tests;
+
+/// <summary>
+/// Integration tests for transaction-related operations against the Mercury sandbox.
+/// </summary>
+public class TransactionTests : IClassFixture<SandboxFixture>
+{
+    private readonly SandboxFixture _sandbox;
+
+    public TransactionTests(SandboxFixture sandbox)
+    {
+        _sandbox = sandbox;
+    }
+
+    [SandboxFact]
+    public async Task GetTransactionsAsync_ReturnsSandboxTransactions()
+    {
+        // Use a wide date range to capture sandbox dummy data.
+        var from = new DateOnly(2020, 1, 1);
+        var to = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var transactions = await _sandbox.Client.GetTransactionsAsync(from, to);
+
+        transactions.Should().NotBeEmpty("sandbox should have pre-loaded transactions");
+    }
+
+    [SandboxFact]
+    public async Task GetAccountTransactionsAsync_ReturnsSandboxTransactions()
+    {
+        var accounts = await _sandbox.Client.GetAccountsAsync();
+        accounts.Should().NotBeEmpty();
+
+        var from = new DateOnly(2020, 1, 1);
+        var to = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var transactions = await _sandbox.Client.GetAccountTransactionsAsync(
+            accounts[0].Id, from, to);
+
+        transactions.Should().NotBeNull();
+        // Sandbox account may or may not have transactions; just verify no errors.
+    }
+
+    [SandboxFact]
+    public async Task GetTransactionAsync_ReturnsSingleTransaction()
+    {
+        var from = new DateOnly(2020, 1, 1);
+        var to = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        var transactions = await _sandbox.Client.GetTransactionsAsync(from, to);
+        transactions.Should().NotBeEmpty("need at least one transaction to test single fetch");
+
+        var transaction = await _sandbox.Client.GetTransactionAsync(transactions[0].Id);
+
+        transaction.Should().NotBeNull();
+        transaction.Id.Should().Be(transactions[0].Id);
+    }
+}

--- a/tests/MercuryBankApi.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/MercuryBankApi.Tests/ServiceCollectionExtensionsTests.cs
@@ -53,7 +53,7 @@ public class ServiceCollectionExtensionsTests
     {
         var options = new MercuryBankOptions();
 
-        options.BaseUrl.Should().Be("https://api.mercury.com/api/v1");
+        options.BaseUrl.Should().Be(MercuryBankOptions.ProductionBaseUrl);
         options.ApiToken.Should().BeEmpty();
         MercuryBankOptions.SectionName.Should().Be("Mercury");
     }


### PR DESCRIPTION
Add a dedicated test project for running integration tests against the Mercury sandbox environment.

## Summary
- Add `ProductionBaseUrl` and `SandboxBaseUrl` constants to `MercuryBankOptions`
- Create `MercuryBankApi.Sandbox.Tests` project with auto-skip when no token is set
- Add account and transaction integration tests (5 tests)
- Add `sandbox-tests.yml` CI workflow (daily + manual dispatch)

Closes #4

Generated with [Claude Code](https://claude.ai/code)