### PR TITLE
fix: remove GitHub Packages push from NuGet publish

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -34,9 +33,6 @@ jobs:
 
       - name: Pack
         run: dotnet pack src/MercuryBankApi/MercuryBankApi.csproj --configuration Release --no-build -o ./artifacts
-
-      - name: Push to GitHub Packages
-        run: dotnet nuget push ./artifacts/*.nupkg --source "https://nuget.pkg.github.com/MonumentalSystems/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
       - name: Push to NuGet.org
         env:


### PR DESCRIPTION
## Summary
- Remove the "Push to GitHub Packages" step from `nuget-publish.yml` — only NuGet.org publishing is needed
- Remove the `packages: write` permission that was only required for the GitHub Packages push

## Test plan
- [ ] Verify the workflow still triggers correctly on a `v*` tag push
- [ ] Confirm NuGet.org push step works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)